### PR TITLE
Fix NSNumber type recognition.

### DIFF
--- a/JSONNode/JSONNode/JSONNode.swift
+++ b/JSONNode/JSONNode/JSONNode.swift
@@ -60,13 +60,14 @@ public enum JSONNode {
     
     private static func nodeRepresentation(fromNumber number: NSNumber) -> JSONNode {
         
-        if NSNumber(booleanLiteral: true).objCType == number.objCType {
+        switch String(cString: number.objCType) {
+        case String(cString: NSNumber(booleanLiteral: true).objCType):
             return .boolean(number.boolValue)
-        } else if NSNumber(value: 3).objCType == number.objCType {
+        case String(cString: NSNumber(value: 3).objCType):
             return .integer(number.intValue)
-        } else if NSNumber(value: 3.14).objCType == number.objCType {
+        case String(cString: NSNumber(value: 3.14).objCType):
             return .floatingPoint(number.doubleValue)
-        } else {
+        default:
             return .null
         }
         


### PR DESCRIPTION
Comparing unsafe pointers directly doesn’t always work. Now parsing into Strings for the comparisons.

<img width="449" alt="nsnumber fun" src="https://cloud.githubusercontent.com/assets/1718852/22511071/51f0f54c-e88c-11e6-9c78-a3968610ebea.png">
